### PR TITLE
Support full set of pipeline query objects options

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   ## If your rubyforge_project name is different, then edit it and comment out
   ## the sub! line in the Rakefile
   s.name              = 'fog'
-  s.version           = '1.19.0'
+  s.version           = '1.19.0.sw.1'
   s.date              = '2013-12-19'
   s.rubyforge_project = 'fog'
 

--- a/lib/fog/aws/requests/data_pipeline/query_objects.rb
+++ b/lib/fog/aws/requests/data_pipeline/query_objects.rb
@@ -13,9 +13,19 @@ module Fog
         # * Options <~Hash> - (optional):
         #   * 'Limit'<~Integer> - Maximum number of objects to return, default 100.
         #   * 'Marker'<~String> - The starting point for the results to be returned.
+        #   * 'Query'<~Hash> - Query that defines the objects to be returned
+        #     * 'Selectors'<~Array<Hash>>:
+        #       * 'FieldName'<~String> -
+        #       * 'Operator'<~Hash>:
+        #         * 'Type'<~String>
+        #         * 'Values'<~Array<String>>
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
+        #     * 'HasMoreResults'<~Boolean> - If True, there are more results that can be
+        #                                    obtained by a subsequent call to QueryObjects.
+        #     * 'Ids'<~Array<String>> - A list of identifiers that match the query selectors.
+        #     * 'Marker'<String> - The starting point for the results to be returned.
         def query_objects(id, sphere, options={})
           params = {
             'pipelineId' => id,
@@ -30,10 +40,48 @@ module Fog
           Fog::JSON.decode(response.body)
         end
 
+        # Queries a pipeline for the names of objects that match a specified set of conditions.
+        # Unlike the above method, this method will automatically follow the pagination Marker
+        # until there are no results remaining.
+        # http://docs.aws.amazon.com/datapipeline/latest/APIReference/API_QueryObjects.html
+        # ==== Parameters
+        # * pipelineId <~String> - The ID of the pipeline
+        # * sphere <~String> - Specifies whether the query applies to components or instances.
+        #                      Allowable values: COMPONENT, INSTANCE, ATTEMPT.
+        # * Options <~Hash> - (optional):
+        #   * 'Limit'<~Integer> - Maximum number of objects to return, default 100.
+        #   * 'Marker'<~String> - The starting point for the results to be returned.
+        #   * 'Query'<~Hash> - Query that defines the objects to be returned
+        #     * 'Selectors'<~Array<Hash>>:
+        #       * 'FieldName'<~String> -
+        #       * 'Operator'<~Hash>:
+        #         * 'Type'<~String>
+        #         * 'Values'<~Array<String>>
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * 'Ids'<~Array<String>> - A list of identifiers that match the query selectors.
+        def query_all_objects(id, sphere, options={})
+          has_more_results = true
+          objects = []
+
+          while has_more_results
+            result = query_objects(id, sphere, options).body
+            objects += result['Ids']
+            has_more_results = result['HasMoreResults']
+            options.merge!('Marker' => result['Marker']) if has_more_results
+          end
+
+          objects
+        end
+
       end
 
       class Mock
-        def query_objects(id, objects)
+        def query_objects(id, objects, params={})
+          Fog::Mock.not_implemented
+        end
+
+        def query_all_objects(id, objects, params={})
           Fog::Mock.not_implemented
         end
       end

--- a/lib/fog/aws/requests/data_pipeline/query_objects.rb
+++ b/lib/fog/aws/requests/data_pipeline/query_objects.rb
@@ -39,49 +39,10 @@ module Fog
 
           Fog::JSON.decode(response.body)
         end
-
-        # Queries a pipeline for the names of objects that match a specified set of conditions.
-        # Unlike the above method, this method will automatically follow the pagination Marker
-        # until there are no results remaining.
-        # http://docs.aws.amazon.com/datapipeline/latest/APIReference/API_QueryObjects.html
-        # ==== Parameters
-        # * pipelineId <~String> - The ID of the pipeline
-        # * sphere <~String> - Specifies whether the query applies to components or instances.
-        #                      Allowable values: COMPONENT, INSTANCE, ATTEMPT.
-        # * Options <~Hash> - (optional):
-        #   * 'Limit'<~Integer> - Maximum number of objects to return, default 100.
-        #   * 'Marker'<~String> - The starting point for the results to be returned.
-        #   * 'Query'<~Hash> - Query that defines the objects to be returned
-        #     * 'Selectors'<~Array<Hash>>:
-        #       * 'FieldName'<~String> -
-        #       * 'Operator'<~Hash>:
-        #         * 'Type'<~String>
-        #         * 'Values'<~Array<String>>
-        # ==== Returns
-        # * response<~Excon::Response>:
-        #   * 'Ids'<~Array<String>> - A list of identifiers that match the query selectors.
-        def query_all_objects(id, sphere, options={})
-          has_more_results = true
-          objects = []
-
-          while has_more_results
-            result = query_objects(id, sphere, options).body
-            objects += result['Ids']
-            has_more_results = result['HasMoreResults']
-            options.merge!('Marker' => result['Marker']) if has_more_results
-          end
-
-          objects
-        end
-
       end
 
       class Mock
         def query_objects(id, objects, params={})
-          Fog::Mock.not_implemented
-        end
-
-        def query_all_objects(id, objects, params={})
           Fog::Mock.not_implemented
         end
       end

--- a/lib/fog/aws/requests/data_pipeline/query_objects.rb
+++ b/lib/fog/aws/requests/data_pipeline/query_objects.rb
@@ -7,17 +7,20 @@ module Fog
         # Queries a pipeline for the names of objects that match a specified set of conditions.
         # http://docs.aws.amazon.com/datapipeline/latest/APIReference/API_QueryObjects.html
         # ==== Parameters
-        # * PipelineId <~String> - The ID of the pipeline
-        # * Sphere <~String> - Specifies whether the query applies to components or instances.
+        # * pipelineId <~String> - The ID of the pipeline
+        # * sphere <~String> - Specifies whether the query applies to components or instances.
         #                      Allowable values: COMPONENT, INSTANCE, ATTEMPT.
+        # * Options <~Hash> - (optional):
+        #   * 'Limit'<~Integer> - Maximum number of objects to return, default 100.
+        #   * 'Marker'<~String> - The starting point for the results to be returned.
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
-        def query_objects(id, sphere)
+        def query_objects(id, sphere, options={})
           params = {
             'pipelineId' => id,
             'sphere' => sphere,
-          }
+          }.merge(options)
 
           response = request({
             :body => Fog::JSON.encode(params),


### PR DESCRIPTION
@tucker250 

Instead of modifying `#query_objects` to strictly pull all of the queried objects, I added a new method, `#query_all_objects` that automatically follows the pagination. I thought that this may be better in case somebody would like to lazily pull the objects in their own library.
